### PR TITLE
Update .angular-cli.json

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -55,13 +55,16 @@
   },
   "lint": [
     {
-      "project": "src/tsconfig.app.json"
+      "project": "src/tsconfig.app.json",
+      "exclude": "**/node_modules/**/*"
     },
     {
-      "project": "src/tsconfig.spec.json"
+      "project": "src/tsconfig.spec.json",
+      "exclude": "**/node_modules/**/*"
     },
     {
-      "project": "e2e/tsconfig.e2e.json"
+      "project": "e2e/tsconfig.e2e.json",
+      "exclude": "**/node_modules/**/*"
     }
   ],
   "test": {


### PR DESCRIPTION
stops ng lint from linting node_modules

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)

[1089](https://github.com/akveo/ng2-admin/issues/1089)

* **What is the new behavior (if this is a feature change)?**

linter runs as expected

* **Other information**:
